### PR TITLE
feat: configure Nginx-RTMP with FFmpeg transcoding, HLS ABR tiers and radio support, closes [STREAM-01] Streaming: Nginx-RTMP server configuration

### DIFF
--- a/streaming/Dockerfile
+++ b/streaming/Dockerfile
@@ -1,7 +1,13 @@
 FROM tiangolo/nginx-rtmp:latest
 
+RUN apt-get update && apt-get install -y \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY nginx.conf /etc/nginx/nginx.conf
 
-EXPOSE 1935 8080
+RUN mkdir -p /tmp/hls/radio
+
+EXPOSE 1935 8082
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/streaming/nginx.conf
+++ b/streaming/nginx.conf
@@ -1,4 +1,6 @@
 worker_processes auto;
+rtmp_auto_push on;
+
 events {
     worker_connections 1024;
 }
@@ -7,8 +9,32 @@ rtmp {
     server {
         listen 1935;
         chunk_size 4096;
+        notify_method get;
 
         application live {
+            live on;
+            record off;
+
+            # Stream key authentication
+            on_publish http://localhost:3000/api/v1/stream/auth;
+
+            # Transcode to 3 HLS quality tiers
+            exec ffmpeg -i rtmp://localhost/live/$name
+                -c:v libx264 -preset veryfast -tune zerolatency
+                    -s 1920x1080 -b:v 4000k -maxrate 4000k -bufsize 8000k
+                    -c:a aac -b:a 128k -ar 44100
+                    -f flv rtmp://localhost/hls/$name_1080p
+                -c:v libx264 -preset veryfast -tune zerolatency
+                    -s 854x480 -b:v 1500k -maxrate 1500k -bufsize 3000k
+                    -c:a aac -b:a 96k -ar 44100
+                    -f flv rtmp://localhost/hls/$name_480p
+                -c:v libx264 -preset veryfast -tune zerolatency
+                    -s 426x240 -b:v 600k -maxrate 600k -bufsize 1200k
+                    -c:a aac -b:a 64k -ar 44100
+                    -f flv rtmp://localhost/hls/$name_240p;
+        }
+
+        application hls {
             live on;
             record off;
 
@@ -16,20 +42,74 @@ rtmp {
             hls_path /tmp/hls;
             hls_fragment 3;
             hls_playlist_length 60;
+            hls_nested on;
+
+            hls_variant _1080p BANDWIDTH=4128000 RESOLUTION=1920x1080;
+            hls_variant _480p  BANDWIDTH=1596000 RESOLUTION=854x480;
+            hls_variant _240p  BANDWIDTH=664000  RESOLUTION=426x240;
+        }
+
+        # Audio-only for radio streams
+        application radio {
+            live on;
+            record off;
+
+            hls on;
+            hls_path /tmp/hls/radio;
+            hls_fragment 3;
+            hls_playlist_length 60;
+
+            exec ffmpeg -i rtmp://localhost/radio/$name
+                -c:a aac -b:a 128k -ar 44100
+                -f flv rtmp://localhost/radio_hls/$name;
+        }
+
+        application radio_hls {
+            live on;
+            record off;
+
+            hls on;
+            hls_path /tmp/hls/radio;
+            hls_fragment 3;
+            hls_playlist_length 60;
         }
     }
 }
 
 http {
+    sendfile off;
+    tcp_nopush on;
+    directio 512;
+    default_type application/octet-stream;
+
     server {
-        listen 8080;
+        listen 8082;
 
         location /hls {
             types {
                 application/vnd.apple.mpegurl m3u8;
-                video/mp2t ts;
+                video/mp2t              ts;
+                audio/aac               aac;
             }
+
             root /tmp;
+
+            add_header Cache-Control no-cache;
+            add_header Access-Control-Allow-Origin *;
+            add_header Access-Control-Allow-Headers *;
+
+            # Serve master playlist for adaptive streams
+            location ~ ^/hls/([^/]+)\.m3u8$ {
+                add_header Cache-Control no-cache;
+            }
+        }
+
+        location /radio {
+            types {
+                application/vnd.apple.mpegurl m3u8;
+                audio/aac               aac;
+            }
+            root /tmp/hls;
             add_header Cache-Control no-cache;
             add_header Access-Control-Allow-Origin *;
         }
@@ -37,6 +117,11 @@ http {
         location /health {
             return 200 'ok';
             add_header Content-Type text/plain;
+        }
+
+        location /stat {
+            rtmp_stat all;
+            rtmp_stat_stylesheet stat.xsl;
         }
     }
 }


### PR DESCRIPTION
## Summary
Full Nginx-RTMP configuration with FFmpeg transcoding.

## What's included
- RTMP ingest on port 1935
- FFmpeg transcodes to 3 HLS tiers: 1080p (4Mbps), 480p (1.5Mbps), 240p (600kbps)
- Separate radio application for audio-only HLS streams
- HLS served over HTTP on port 8082 (avoids conflict with existing services)
- Stream key auth hook to Go API
- CORS headers for mobile client access

## Test
```bash
docker compose up -d nginx-rtmp
curl http://localhost:8082/health  # → ok
# Push test stream with OBS to rtmp://localhost/live/test
# Play: http://localhost:8082/hls/test.m3u8
```

Closes #15