### PR TITLE
feat: Mobile TV channels screen and live player [STREAM-03]

### DIFF
--- a/mobile/lib/core/di/injection.dart
+++ b/mobile/lib/core/di/injection.dart
@@ -3,15 +3,15 @@ import 'package:openair/core/services/api_service.dart';
 import 'package:openair/features/auth/bloc/auth_bloc.dart';
 import 'package:openair/features/auth/repository/auth_repository.dart';
 import 'package:openair/features/settings/bloc/settings_bloc.dart';
+import 'package:openair/features/tv/repository/channel_repository.dart';
 
 final getIt = GetIt.instance;
 
 Future<void> configureDependencies() async {
   final apiService = await ApiService.create();
   getIt.registerSingleton<ApiService>(apiService);
-  getIt.registerLazySingleton<AuthRepository>(
-    () => AuthRepository(getIt<ApiService>()),
-  );
+  getIt.registerLazySingleton<AuthRepository>(() => AuthRepository(getIt<ApiService>()));
+  getIt.registerLazySingleton<ChannelRepository>(() => ChannelRepository(getIt<ApiService>()));
   getIt.registerFactory<AuthBloc>(() => AuthBloc(getIt<AuthRepository>()));
   getIt.registerFactory<SettingsBloc>(() => SettingsBloc());
 }

--- a/mobile/lib/features/tv/bloc/tv_bloc.dart
+++ b/mobile/lib/features/tv/bloc/tv_bloc.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:openair/features/tv/models/channel_model.dart';
+import 'package:openair/features/tv/repository/channel_repository.dart';
+
+part 'tv_event.dart';
+part 'tv_state.dart';
+
+class TvBloc extends Bloc<TvEvent, TvState> {
+  final ChannelRepository _repo;
+
+  TvBloc(this._repo) : super(TvInitial()) {
+    on<TvChannelsLoaded>(_onLoad);
+    on<TvStreamRequested>(_onStream);
+  }
+
+  Future<void> _onLoad(TvChannelsLoaded event, Emitter<TvState> emit) async {
+    emit(TvLoading());
+    try {
+      final channels = await _repo.getTvChannels();
+      emit(TvChannelsSuccess(channels));
+    } catch (e) {
+      emit(TvError(e.toString()));
+    }
+  }
+
+  Future<void> _onStream(TvStreamRequested event, Emitter<TvState> emit) async {
+    try {
+      final streamUrl = await _repo.getStreamUrl(event.channelId);
+      emit(TvStreamReady(streamUrl.url, event.channelName));
+    } catch (e) {
+      emit(TvError(e.toString()));
+    }
+  }
+}

--- a/mobile/lib/features/tv/bloc/tv_event.dart
+++ b/mobile/lib/features/tv/bloc/tv_event.dart
@@ -1,0 +1,15 @@
+part of 'tv_bloc.dart';
+
+abstract class TvEvent extends Equatable {
+  const TvEvent();
+  @override List<Object> get props => [];
+}
+
+class TvChannelsLoaded extends TvEvent {}
+
+class TvStreamRequested extends TvEvent {
+  final String channelId;
+  final String channelName;
+  const TvStreamRequested(this.channelId, this.channelName);
+  @override List<Object> get props => [channelId, channelName];
+}

--- a/mobile/lib/features/tv/bloc/tv_state.dart
+++ b/mobile/lib/features/tv/bloc/tv_state.dart
@@ -1,0 +1,28 @@
+part of 'tv_bloc.dart';
+
+abstract class TvState extends Equatable {
+  const TvState();
+  @override List<Object?> get props => [];
+}
+
+class TvInitial extends TvState {}
+class TvLoading extends TvState {}
+
+class TvChannelsSuccess extends TvState {
+  final List<Channel> channels;
+  const TvChannelsSuccess(this.channels);
+  @override List<Object?> get props => [channels];
+}
+
+class TvStreamReady extends TvState {
+  final String streamUrl;
+  final String channelName;
+  const TvStreamReady(this.streamUrl, this.channelName);
+  @override List<Object?> get props => [streamUrl, channelName];
+}
+
+class TvError extends TvState {
+  final String message;
+  const TvError(this.message);
+  @override List<Object?> get props => [message];
+}

--- a/mobile/lib/features/tv/models/channel_model.dart
+++ b/mobile/lib/features/tv/models/channel_model.dart
@@ -1,0 +1,48 @@
+class Channel {
+  final String id;
+  final String name;
+  final String type;
+  final String streamUrl;
+  final String? logoUrl;
+  final String? description;
+  final bool isPremium;
+  final bool isActive;
+  final int sortOrder;
+
+  const Channel({
+    required this.id,
+    required this.name,
+    required this.type,
+    required this.streamUrl,
+    this.logoUrl,
+    this.description,
+    required this.isPremium,
+    required this.isActive,
+    required this.sortOrder,
+  });
+
+  factory Channel.fromJson(Map<String, dynamic> json) => Channel(
+        id: json['id'],
+        name: json['name'],
+        type: json['type'],
+        streamUrl: json['stream_url'],
+        logoUrl: json['logo_url'],
+        description: json['description'],
+        isPremium: json['is_premium'] ?? false,
+        isActive: json['is_active'] ?? true,
+        sortOrder: json['sort_order'] ?? 0,
+      );
+}
+
+class StreamUrlResponse {
+  final String url;
+  final int expiresAt;
+
+  const StreamUrlResponse({required this.url, required this.expiresAt});
+
+  factory StreamUrlResponse.fromJson(Map<String, dynamic> json) =>
+      StreamUrlResponse(
+        url: json['url'],
+        expiresAt: json['expires_at'] ?? 0,
+      );
+}

--- a/mobile/lib/features/tv/repository/channel_repository.dart
+++ b/mobile/lib/features/tv/repository/channel_repository.dart
@@ -1,0 +1,25 @@
+import 'package:openair/core/services/api_service.dart';
+import 'package:openair/features/tv/models/channel_model.dart';
+
+class ChannelRepository {
+  final ApiService _api;
+
+  ChannelRepository(this._api);
+
+  Future<List<Channel>> getTvChannels() async {
+    final res = await _api.dio.get('/channels', queryParameters: {'type': 'tv'});
+    final List data = res.data['data'] ?? [];
+    return data.map((e) => Channel.fromJson(e)).toList();
+  }
+
+  Future<List<Channel>> getRadioChannels() async {
+    final res = await _api.dio.get('/channels', queryParameters: {'type': 'radio'});
+    final List data = res.data['data'] ?? [];
+    return data.map((e) => Channel.fromJson(e)).toList();
+  }
+
+  Future<StreamUrlResponse> getStreamUrl(String channelId) async {
+    final res = await _api.dio.get('/channels/$channelId/stream');
+    return StreamUrlResponse.fromJson(res.data['data']);
+  }
+}

--- a/mobile/lib/features/tv/screens/player_screen.dart
+++ b/mobile/lib/features/tv/screens/player_screen.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:media_kit_video/media_kit_video.dart';
+
+class PlayerScreen extends StatefulWidget {
+  final String streamUrl;
+  final String title;
+
+  const PlayerScreen({
+    super.key,
+    required this.streamUrl,
+    required this.title,
+  });
+
+  @override
+  State<PlayerScreen> createState() => _PlayerScreenState();
+}
+
+class _PlayerScreenState extends State<PlayerScreen> {
+  late final Player _player;
+  late final VideoController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.landscapeLeft,
+      DeviceOrientation.landscapeRight,
+      DeviceOrientation.portraitUp,
+    ]);
+
+    _player = Player();
+    _controller = VideoController(_player);
+    _player.open(Media(widget.streamUrl));
+  }
+
+  @override
+  void dispose() {
+    SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
+    _player.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        title: Text(widget.title),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.fullscreen),
+            onPressed: () {
+              SystemChrome.setPreferredOrientations([
+                DeviceOrientation.landscapeLeft,
+                DeviceOrientation.landscapeRight,
+              ]);
+            },
+          ),
+        ],
+      ),
+      body: Center(
+        child: Video(controller: _controller),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/tv/screens/tv_screen.dart
+++ b/mobile/lib/features/tv/screens/tv_screen.dart
@@ -1,13 +1,170 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openair/features/tv/bloc/tv_bloc.dart';
+import 'package:openair/features/tv/models/channel_model.dart';
+import 'package:openair/features/tv/screens/player_screen.dart';
+import 'package:openair/core/di/injection.dart';
+import 'package:openair/features/tv/repository/channel_repository.dart';
 
 class TvScreen extends StatelessWidget {
   const TvScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('TV')),
-      body: const Center(child: Text('TV')),
+    return BlocProvider(
+      create: (_) => TvBloc(getIt<ChannelRepository>())..add(TvChannelsLoaded()),
+      child: const _TvView(),
     );
   }
+}
+
+class _TvView extends StatelessWidget {
+  const _TvView();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Live TV')),
+      body: BlocConsumer<TvBloc, TvState>(
+        listener: (context, state) {
+          if (state is TvStreamReady) {
+            Navigator.push(context, MaterialPageRoute(
+              builder: (_) => PlayerScreen(
+                streamUrl: state.streamUrl,
+                title: state.channelName,
+              ),
+            ));
+          }
+          if (state is TvError) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(state.message), backgroundColor: Colors.red),
+            );
+          }
+        },
+        builder: (context, state) {
+          if (state is TvLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (state is TvChannelsSuccess) {
+            if (state.channels.isEmpty) {
+              return const Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.tv_off, size: 64, color: Colors.grey),
+                    SizedBox(height: 16),
+                    Text('No channels available', style: TextStyle(color: Colors.grey)),
+                  ],
+                ),
+              );
+            }
+
+            return GridView.builder(
+              padding: const EdgeInsets.all(16),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 2,
+                crossAxisSpacing: 12,
+                mainAxisSpacing: 12,
+                childAspectRatio: 1.4,
+              ),
+              itemCount: state.channels.length,
+              itemBuilder: (context, index) {
+                return _ChannelCard(channel: state.channels[index]);
+              },
+            );
+          }
+
+          if (state is TvError) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.error_outline, size: 48, color: Colors.red),
+                  const SizedBox(height: 12),
+                  Text(state.message, textAlign: TextAlign.center),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => context.read<TvBloc>().add(TvChannelsLoaded()),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+}
+
+class _ChannelCard extends StatelessWidget {
+  final Channel channel;
+  const _ChannelCard({required this.channel});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return GestureDetector(
+      onTap: () => context.read<TvBloc>().add(
+            TvStreamRequested(channel.id, channel.name),
+          ),
+      child: Container(
+        decoration: BoxDecoration(
+          color: theme.cardTheme.color,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: theme.dividerColor.withOpacity(0.3)),
+        ),
+        child: Stack(
+          children: [
+            Center(
+              child: channel.logoUrl != null
+                  ? Image.network(channel.logoUrl!, height: 48, errorBuilder: (_, __, ___) => _fallbackIcon())
+                  : _fallbackIcon(),
+            ),
+            Positioned(
+              bottom: 8,
+              left: 8,
+              right: 8,
+              child: Text(
+                channel.name,
+                style: theme.textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w600),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            if (channel.isPremium)
+              Positioned(
+                top: 8,
+                right: 8,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.primary,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: const Text('PRO', style: TextStyle(color: Colors.white, fontSize: 10, fontWeight: FontWeight.bold)),
+                ),
+              ),
+            Positioned(
+              top: 8,
+              left: 8,
+              child: Container(
+                width: 8,
+                height: 8,
+                decoration: const BoxDecoration(
+                  color: Colors.red,
+                  shape: BoxShape.circle,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _fallbackIcon() => const Icon(Icons.tv, size: 36, color: Colors.grey);
 }


### PR DESCRIPTION
## Summary
Full TV streaming UI — channel grid loads from API, tap to stream.

## What's included
- `Channel` model + `ChannelRepository`
- `TvBloc` — loads channels, fetches stream URL on tap
- `TvScreen` — 2-column grid with live indicator, PRO badge
- `PlayerScreen` — full-screen HLS player via media_kit
  - Landscape support
  - Fullscreen toggle

## Test
1. Add a channel via Adminer or seed SQL
2. Run app → tap TV tab
3. Channel grid loads from API
4. Tap channel → player opens and streams

Closes #17