### PR TITLE
feat: VOD backend — catalogue, stream URLs, watch history [VOD-01]

### DIFF
--- a/backend/internal/content/errors.go
+++ b/backend/internal/content/errors.go
@@ -1,0 +1,8 @@
+package content
+
+import "errors"
+
+var (
+	ErrContentNotFound = errors.New("content not found")
+	ErrPremiumRequired = errors.New("premium subscription required")
+)

--- a/backend/internal/content/handler.go
+++ b/backend/internal/content/handler.go
@@ -1,0 +1,184 @@
+package content
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/TgkCapture/openair/pkg/utils"
+)
+
+type Handler struct {
+	svc *Service
+}
+
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+func (h *Handler) GetAll(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	perPage, _ := strconv.Atoi(c.DefaultQuery("per_page", "20"))
+
+	result, err := h.svc.GetAll(
+		c.Request.Context(),
+		c.Query("type"),
+		c.Query("category"),
+		c.Query("q"),
+		page, perPage,
+	)
+	if err != nil {
+		log.Printf("ERROR GetAll content: %v", err)
+		utils.InternalError(c)
+		return
+	}
+	utils.OKWithMeta(c, result.Items, &utils.Meta{
+		Page:    result.Page,
+		PerPage: result.PerPage,
+		Total:   result.Total,
+	})
+}
+
+func (h *Handler) GetByID(c *gin.Context) {
+	item, err := h.svc.GetByID(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		if errors.Is(err, ErrContentNotFound) {
+			utils.NotFound(c, "content not found")
+			return
+		}
+		utils.InternalError(c)
+		return
+	}
+	utils.OK(c, item)
+}
+
+func (h *Handler) GetStreamURL(c *gin.Context) {
+	userID := c.GetString("user_id")
+	userRole := c.GetString("user_role")
+	isPremium := userRole == "admin"
+
+	url, err := h.svc.GetStreamURL(c.Request.Context(), c.Param("id"), userID, isPremium)
+	if err != nil {
+		if errors.Is(err, ErrContentNotFound) {
+			utils.NotFound(c, "content not found")
+			return
+		}
+		if errors.Is(err, ErrPremiumRequired) {
+			c.JSON(http.StatusForbidden, utils.Response{
+				Success: false,
+				Error:   &utils.APIError{Code: "PREMIUM_REQUIRED", Message: "premium subscription required"},
+			})
+			return
+		}
+		utils.InternalError(c)
+		return
+	}
+	utils.OK(c, gin.H{"url": url})
+}
+
+func (h *Handler) GetPublicStreamURL(c *gin.Context) {
+	url, err := h.svc.GetStreamURL(c.Request.Context(), c.Param("id"), "", false)
+	if err != nil {
+		if errors.Is(err, ErrContentNotFound) {
+			utils.NotFound(c, "content not found")
+			return
+		}
+		if errors.Is(err, ErrPremiumRequired) {
+			c.JSON(http.StatusForbidden, utils.Response{
+				Success: false,
+				Error:   &utils.APIError{Code: "PREMIUM_REQUIRED", Message: "login required for premium content"},
+			})
+			return
+		}
+		utils.InternalError(c)
+		return
+	}
+	utils.OK(c, gin.H{"url": url})
+}
+
+func (h *Handler) GetCategories(c *gin.Context) {
+	cats, err := h.svc.GetCategories(c.Request.Context())
+	if err != nil {
+		utils.InternalError(c)
+		return
+	}
+	if cats == nil {
+		cats = []string{}
+	}
+	utils.OK(c, cats)
+}
+
+func (h *Handler) SaveWatchHistory(c *gin.Context) {
+	userID := c.GetString("user_id")
+	var body struct {
+		ContentID    string `json:"content_id" binding:"required"`
+		ProgressSecs int    `json:"progress_secs"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		utils.BadRequest(c, "VALIDATION_ERROR", err.Error())
+		return
+	}
+	if err := h.svc.SaveWatchHistory(c.Request.Context(), userID, body.ContentID, body.ProgressSecs); err != nil {
+		utils.InternalError(c)
+		return
+	}
+	utils.OK(c, gin.H{"message": "saved"})
+}
+
+func (h *Handler) GetWatchHistory(c *gin.Context) {
+	userID := c.GetString("user_id")
+	items, err := h.svc.GetWatchHistory(c.Request.Context(), userID)
+	if err != nil {
+		utils.InternalError(c)
+		return
+	}
+	if items == nil {
+		items = []*Content{}
+	}
+	utils.OK(c, items)
+}
+
+func (h *Handler) Create(c *gin.Context) {
+	var req CreateContentRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.BadRequest(c, "VALIDATION_ERROR", err.Error())
+		return
+	}
+	item, err := h.svc.Create(c.Request.Context(), req)
+	if err != nil {
+		utils.InternalError(c)
+		return
+	}
+	utils.Created(c, item)
+}
+
+func (h *Handler) Update(c *gin.Context) {
+	var req UpdateContentRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.BadRequest(c, "VALIDATION_ERROR", err.Error())
+		return
+	}
+	item, err := h.svc.Update(c.Request.Context(), c.Param("id"), req)
+	if err != nil {
+		utils.InternalError(c)
+		return
+	}
+	utils.OK(c, item)
+}
+
+func (h *Handler) ToggleAccess(c *gin.Context) {
+	var body struct {
+		IsPremium bool `json:"is_premium"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		utils.BadRequest(c, "VALIDATION_ERROR", err.Error())
+		return
+	}
+	if err := h.svc.ToggleAccess(c.Request.Context(), c.Param("id"), body.IsPremium); err != nil {
+		utils.InternalError(c)
+		return
+	}
+	utils.OK(c, gin.H{"message": "access updated"})
+}

--- a/backend/internal/content/model.go
+++ b/backend/internal/content/model.go
@@ -1,0 +1,50 @@
+package content
+
+import "time"
+
+type Content struct {
+	ID           string     `json:"id"`
+	ChannelID    *string    `json:"channel_id,omitempty"`
+	Title        string     `json:"title"`
+	Description  *string    `json:"description,omitempty"`
+	Type         string     `json:"type"`
+	FileURL      string     `json:"file_url"`
+	ThumbnailURL *string    `json:"thumbnail_url,omitempty"`
+	Category     *string    `json:"category,omitempty"`
+	DurationSecs *int       `json:"duration_secs,omitempty"`
+	IsPremium    bool       `json:"is_premium"`
+	IsPublished  bool       `json:"is_published"`
+	ViewCount    int        `json:"view_count"`
+	PublishedAt  *time.Time `json:"published_at,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+}
+
+type ContentListResponse struct {
+	Items  []*Content `json:"items"`
+	Total  int        `json:"total"`
+	Page   int        `json:"page"`
+	PerPage int       `json:"per_page"`
+}
+
+type CreateContentRequest struct {
+	ChannelID    *string `json:"channel_id"`
+	Title        string  `json:"title" binding:"required,min=2"`
+	Description  *string `json:"description"`
+	Type         string  `json:"type" binding:"required,oneof=vod promo highlight"`
+	FileURL      string  `json:"file_url" binding:"required"`
+	ThumbnailURL *string `json:"thumbnail_url"`
+	Category     *string `json:"category"`
+	DurationSecs *int    `json:"duration_secs"`
+	IsPremium    bool    `json:"is_premium"`
+	IsPublished  bool    `json:"is_published"`
+}
+
+type UpdateContentRequest struct {
+	Title        string  `json:"title" binding:"required,min=2"`
+	Description  *string `json:"description"`
+	ThumbnailURL *string `json:"thumbnail_url"`
+	Category     *string `json:"category"`
+	DurationSecs *int    `json:"duration_secs"`
+	IsPremium    bool    `json:"is_premium"`
+	IsPublished  bool    `json:"is_published"`
+}

--- a/backend/internal/content/repository.go
+++ b/backend/internal/content/repository.go
@@ -1,0 +1,225 @@
+package content
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Repository struct {
+	db *pgxpool.Pool
+}
+
+func NewRepository(db *pgxpool.Pool) *Repository {
+	return &Repository{db: db}
+}
+
+func (r *Repository) GetAll(ctx context.Context, contentType, category, search string, page, perPage int) (*ContentListResponse, error) {
+	offset := (page - 1) * perPage
+	conditions := []string{"is_published = true"}
+	args := []interface{}{}
+	argIdx := 1
+
+	if contentType != "" {
+		conditions = append(conditions, fmt.Sprintf("type = $%d", argIdx))
+		args = append(args, contentType)
+		argIdx++
+	}
+	if category != "" {
+		conditions = append(conditions, fmt.Sprintf("category = $%d", argIdx))
+		args = append(args, category)
+		argIdx++
+	}
+	if search != "" {
+		conditions = append(conditions, fmt.Sprintf("title ILIKE $%d", argIdx))
+		args = append(args, "%"+search+"%")
+		argIdx++
+	}
+
+	where := "WHERE " + strings.Join(conditions, " AND ")
+
+	var total int
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM content %s", where)
+	if err := r.db.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, fmt.Errorf("count content: %w", err)
+	}
+
+	args = append(args, perPage, offset)
+	query := fmt.Sprintf(`
+		SELECT id, channel_id, title, description, type, file_url,
+		       thumbnail_url, category, duration_secs, is_premium,
+		       is_published, view_count, published_at, created_at
+		FROM content %s
+		ORDER BY published_at DESC NULLS LAST, created_at DESC
+		LIMIT $%d OFFSET $%d`, where, argIdx, argIdx+1)
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("get content: %w", err)
+	}
+	defer rows.Close()
+
+	var items []*Content
+	for rows.Next() {
+		c := &Content{}
+		if err := rows.Scan(&c.ID, &c.ChannelID, &c.Title, &c.Description,
+			&c.Type, &c.FileURL, &c.ThumbnailURL, &c.Category,
+			&c.DurationSecs, &c.IsPremium, &c.IsPublished,
+			&c.ViewCount, &c.PublishedAt, &c.CreatedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, c)
+	}
+
+	if items == nil {
+		items = []*Content{}
+	}
+
+	return &ContentListResponse{
+		Items:   items,
+		Total:   total,
+		Page:    page,
+		PerPage: perPage,
+	}, nil
+}
+
+func (r *Repository) GetByID(ctx context.Context, id string) (*Content, error) {
+	c := &Content{}
+	query := `
+		SELECT id, channel_id, title, description, type, file_url,
+		       thumbnail_url, category, duration_secs, is_premium,
+		       is_published, view_count, published_at, created_at
+		FROM content WHERE id = $1`
+
+	err := r.db.QueryRow(ctx, query, id).Scan(
+		&c.ID, &c.ChannelID, &c.Title, &c.Description,
+		&c.Type, &c.FileURL, &c.ThumbnailURL, &c.Category,
+		&c.DurationSecs, &c.IsPremium, &c.IsPublished,
+		&c.ViewCount, &c.PublishedAt, &c.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get content by id: %w", err)
+	}
+	return c, nil
+}
+
+func (r *Repository) IncrementViewCount(ctx context.Context, id string) {
+	_, _ = r.db.Exec(ctx, `UPDATE content SET view_count = view_count + 1 WHERE id = $1`, id)
+}
+
+func (r *Repository) Create(ctx context.Context, req CreateContentRequest) (*Content, error) {
+	c := &Content{}
+	query := `
+		INSERT INTO content (channel_id, title, description, type, file_url,
+		                     thumbnail_url, category, duration_secs, is_premium, is_published)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+		RETURNING id, channel_id, title, description, type, file_url,
+		          thumbnail_url, category, duration_secs, is_premium,
+		          is_published, view_count, published_at, created_at`
+
+	err := r.db.QueryRow(ctx, query,
+		req.ChannelID, req.Title, req.Description, req.Type,
+		req.FileURL, req.ThumbnailURL, req.Category,
+		req.DurationSecs, req.IsPremium, req.IsPublished,
+	).Scan(&c.ID, &c.ChannelID, &c.Title, &c.Description,
+		&c.Type, &c.FileURL, &c.ThumbnailURL, &c.Category,
+		&c.DurationSecs, &c.IsPremium, &c.IsPublished,
+		&c.ViewCount, &c.PublishedAt, &c.CreatedAt)
+
+	return c, err
+}
+
+func (r *Repository) Update(ctx context.Context, id string, req UpdateContentRequest) (*Content, error) {
+	c := &Content{}
+	query := `
+		UPDATE content
+		SET title=$2, description=$3, thumbnail_url=$4, category=$5,
+		    duration_secs=$6, is_premium=$7, is_published=$8, updated_at=NOW()
+		WHERE id=$1
+		RETURNING id, channel_id, title, description, type, file_url,
+		          thumbnail_url, category, duration_secs, is_premium,
+		          is_published, view_count, published_at, created_at`
+
+	err := r.db.QueryRow(ctx, query,
+		id, req.Title, req.Description, req.ThumbnailURL,
+		req.Category, req.DurationSecs, req.IsPremium, req.IsPublished,
+	).Scan(&c.ID, &c.ChannelID, &c.Title, &c.Description,
+		&c.Type, &c.FileURL, &c.ThumbnailURL, &c.Category,
+		&c.DurationSecs, &c.IsPremium, &c.IsPublished,
+		&c.ViewCount, &c.PublishedAt, &c.CreatedAt)
+
+	return c, err
+}
+
+func (r *Repository) ToggleAccess(ctx context.Context, id string, isPremium bool) error {
+	_, err := r.db.Exec(ctx,
+		`UPDATE content SET is_premium=$2, updated_at=NOW() WHERE id=$1`,
+		id, isPremium)
+	return err
+}
+
+func (r *Repository) GetCategories(ctx context.Context) ([]string, error) {
+	rows, err := r.db.Query(ctx,
+		`SELECT DISTINCT category FROM content WHERE category IS NOT NULL AND is_published=true ORDER BY category`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var cats []string
+	for rows.Next() {
+		var cat string
+		if err := rows.Scan(&cat); err == nil {
+			cats = append(cats, cat)
+		}
+	}
+	return cats, nil
+}
+
+func (r *Repository) SaveWatchHistory(ctx context.Context, userID, contentID string, progressSecs int) error {
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO watch_history (user_id, content_id, progress_secs, last_watched_at)
+		VALUES ($1, $2, $3, NOW())
+		ON CONFLICT (user_id, content_id)
+		DO UPDATE SET progress_secs=$3, last_watched_at=NOW()`,
+		userID, contentID, progressSecs)
+	return err
+}
+
+func (r *Repository) GetWatchHistory(ctx context.Context, userID string, limit int) ([]*Content, error) {
+	query := `
+		SELECT c.id, c.channel_id, c.title, c.description, c.type, c.file_url,
+		       c.thumbnail_url, c.category, c.duration_secs, c.is_premium,
+		       c.is_published, c.view_count, c.published_at, c.created_at
+		FROM content c
+		JOIN watch_history wh ON wh.content_id = c.id
+		WHERE wh.user_id = $1
+		ORDER BY wh.last_watched_at DESC
+		LIMIT $2`
+
+	rows, err := r.db.Query(ctx, query, userID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var items []*Content
+	for rows.Next() {
+		c := &Content{}
+		if err := rows.Scan(&c.ID, &c.ChannelID, &c.Title, &c.Description,
+			&c.Type, &c.FileURL, &c.ThumbnailURL, &c.Category,
+			&c.DurationSecs, &c.IsPremium, &c.IsPublished,
+			&c.ViewCount, &c.PublishedAt, &c.CreatedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, c)
+	}
+	return items, nil
+}

--- a/backend/internal/content/service.go
+++ b/backend/internal/content/service.go
@@ -1,0 +1,93 @@
+package content
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/TgkCapture/openair/pkg/config"
+)
+
+type Service struct {
+	repo *Repository
+	cfg  *config.Config
+}
+
+func NewService(repo *Repository, cfg *config.Config) *Service {
+	return &Service{repo: repo, cfg: cfg}
+}
+
+func (s *Service) GetAll(ctx context.Context, contentType, category, search string, page, perPage int) (*ContentListResponse, error) {
+	if page < 1 {
+		page = 1
+	}
+	if perPage < 1 || perPage > 50 {
+		perPage = 20
+	}
+	return s.repo.GetAll(ctx, contentType, category, search, page, perPage)
+}
+
+func (s *Service) GetByID(ctx context.Context, id string) (*Content, error) {
+	c, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if c == nil {
+		return nil, ErrContentNotFound
+	}
+	return c, nil
+}
+
+func (s *Service) GetStreamURL(ctx context.Context, id, userID string, isPremium bool) (string, error) {
+	c, err := s.GetByID(ctx, id)
+	if err != nil {
+		return "", err
+	}
+
+	go s.repo.IncrementViewCount(ctx, id)
+
+	if c.IsPremium && !isPremium {
+		return "", ErrPremiumRequired
+	}
+
+	if !c.IsPremium {
+		return c.FileURL, nil
+	}
+
+	expiresAt := time.Now().Add(2 * time.Hour).Unix()
+	token := s.signURL(c.FileURL, userID, expiresAt)
+	return fmt.Sprintf("%s?token=%s&expires=%d", c.FileURL, token, expiresAt), nil
+}
+
+func (s *Service) signURL(url, userID string, expiresAt int64) string {
+	h := hmac.New(sha256.New, []byte(s.cfg.RTMPSecret))
+	h.Write([]byte(fmt.Sprintf("%s:%s:%d", url, userID, expiresAt)))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func (s *Service) Create(ctx context.Context, req CreateContentRequest) (*Content, error) {
+	return s.repo.Create(ctx, req)
+}
+
+func (s *Service) Update(ctx context.Context, id string, req UpdateContentRequest) (*Content, error) {
+	return s.repo.Update(ctx, id, req)
+}
+
+func (s *Service) ToggleAccess(ctx context.Context, id string, isPremium bool) error {
+	return s.repo.ToggleAccess(ctx, id, isPremium)
+}
+
+func (s *Service) GetCategories(ctx context.Context) ([]string, error) {
+	return s.repo.GetCategories(ctx)
+}
+
+func (s *Service) SaveWatchHistory(ctx context.Context, userID, contentID string, progressSecs int) error {
+	return s.repo.SaveWatchHistory(ctx, userID, contentID, progressSecs)
+}
+
+func (s *Service) GetWatchHistory(ctx context.Context, userID string) ([]*Content, error) {
+	return s.repo.GetWatchHistory(ctx, userID, 20)
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/TgkCapture/openair/pkg/config"
 	"github.com/TgkCapture/openair/pkg/middleware"
 	"github.com/TgkCapture/openair/pkg/token"
+	"github.com/TgkCapture/openair/internal/content"
 )
 
 type Server struct {
@@ -83,6 +84,16 @@ func (s *Server) setupRoutes() {
 	v1.GET("/channels/:id", channelHandler.GetByID)
 	v1.GET("/channels/:id/stream", channelHandler.GetPublicStreamURL)
 
+	// Content / VOD
+	contentRepo := content.NewRepository(s.db)
+	contentSvc := content.NewService(contentRepo, s.cfg)
+	contentHandler := content.NewHandler(contentSvc)
+
+	v1.GET("/vod", contentHandler.GetAll)
+	v1.GET("/vod/categories", contentHandler.GetCategories)
+	v1.GET("/vod/:id", contentHandler.GetByID)
+	v1.GET("/vod/:id/stream", contentHandler.GetPublicStreamURL)
+
 	// Protected routes
 	protected := v1.Group("")
 	protected.Use(middleware.Auth(s.tokenManager))
@@ -94,6 +105,10 @@ func (s *Server) setupRoutes() {
 		// Channels — authenticated stream URL
 		protected.GET("/channels/:id/stream/secure", channelHandler.GetStreamURL)
 
+		protected.GET("/vod/:id/stream/secure", contentHandler.GetStreamURL)
+		protected.POST("/watch-history", contentHandler.SaveWatchHistory)
+		protected.GET("/watch-history", contentHandler.GetWatchHistory)
+
 		// Admin only
 		admin := protected.Group("/admin")
 		admin.Use(middleware.RequireRole("admin"))
@@ -102,6 +117,10 @@ func (s *Server) setupRoutes() {
 			admin.PUT("/channels/:id", channelHandler.Update)
 			admin.DELETE("/channels/:id", channelHandler.Delete)
 			admin.PATCH("/channels/:id/access", channelHandler.ToggleAccess)
+
+			admin.POST("/vod", contentHandler.Create)
+			admin.PUT("/vod/:id", contentHandler.Update)
+			admin.PATCH("/vod/:id/access", contentHandler.ToggleAccess)
 		}
 	}
 }


### PR DESCRIPTION
## Endpoints added
| Method | Endpoint | Description |
|---|---|---|
| GET | /api/v1/vod | Paginated VOD catalogue (filter by type, category, search) |
| GET | /api/v1/vod/categories | List distinct categories |
| GET | /api/v1/vod/:id | Single VOD detail |
| GET | /api/v1/vod/:id/stream | Public stream URL |
| GET | /api/v1/vod/:id/stream/secure | Authenticated + premium check |
| POST | /watch-history | Save playback progress |
| GET | /watch-history | Get user's continue watching list |
| POST | /admin/vod | Create VOD |
| PUT | /admin/vod/:id | Update VOD |
| PATCH | /admin/vod/:id/access | Toggle free/premium |

Closes #19