### PR TITLE
Implement podcasts and episodes endpoints

### DIFF
--- a/backend/internal/podcasts/handler.go
+++ b/backend/internal/podcasts/handler.go
@@ -1,0 +1,99 @@
+package podcasts
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/TgkCapture/openair/pkg/utils"
+)
+
+type Handler struct {
+	svc *Service
+}
+
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+func (h *Handler) GetAll(c *gin.Context) {
+	podcasts, err := h.svc.GetAll(c.Request.Context())
+	if err != nil {
+		utils.InternalError(c)
+		return
+	}
+	utils.OK(c, podcasts)
+}
+
+func (h *Handler) GetByID(c *gin.Context) {
+	p, err := h.svc.GetByID(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		if errors.Is(err, ErrPodcastNotFound) {
+			utils.NotFound(c, "podcast not found")
+			return
+		}
+		utils.InternalError(c)
+		return
+	}
+	utils.OK(c, p)
+}
+
+func (h *Handler) GetEpisodes(c *gin.Context) {
+	episodes, err := h.svc.GetEpisodes(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		utils.InternalError(c)
+		return
+	}
+	utils.OK(c, episodes)
+}
+
+func (h *Handler) GetEpisodeStreamURL(c *gin.Context) {
+	userRole := c.GetString("user_role")
+	isPremium := userRole == "admin"
+
+	url, err := h.svc.GetEpisodeStreamURL(c.Request.Context(), c.Param("episodeId"), isPremium)
+	if err != nil {
+		if errors.Is(err, ErrEpisodeNotFound) {
+			utils.NotFound(c, "episode not found")
+			return
+		}
+		if errors.Is(err, ErrPremiumRequired) {
+			c.JSON(http.StatusForbidden, utils.Response{
+				Success: false,
+				Error:   &utils.APIError{Code: "PREMIUM_REQUIRED", Message: "premium required"},
+			})
+			return
+		}
+		utils.InternalError(c)
+		return
+	}
+	utils.OK(c, gin.H{"url": url})
+}
+
+func (h *Handler) CreatePodcast(c *gin.Context) {
+	var req CreatePodcastRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.BadRequest(c, "VALIDATION_ERROR", err.Error())
+		return
+	}
+	p, err := h.svc.CreatePodcast(c.Request.Context(), req)
+	if err != nil {
+		utils.InternalError(c)
+		return
+	}
+	utils.Created(c, p)
+}
+
+func (h *Handler) CreateEpisode(c *gin.Context) {
+	var req CreateEpisodeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.BadRequest(c, "VALIDATION_ERROR", err.Error())
+		return
+	}
+	p, err := h.svc.CreateEpisode(c.Request.Context(), req)
+	if err != nil {
+		utils.InternalError(c)
+		return
+	}
+	utils.Created(c, p)
+}

--- a/backend/internal/podcasts/model.go
+++ b/backend/internal/podcasts/model.go
@@ -1,0 +1,51 @@
+package podcasts
+
+import "time"
+
+type Podcast struct {
+	ID          string    `json:"id"`
+	Title       string    `json:"title"`
+	Description *string   `json:"description,omitempty"`
+	ArtworkURL  *string   `json:"artwork_url,omitempty"`
+	Author      *string   `json:"author,omitempty"`
+	Category    *string   `json:"category,omitempty"`
+	IsPremium   bool      `json:"is_premium"`
+	IsActive    bool      `json:"is_active"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+type Episode struct {
+	ID            string     `json:"id"`
+	PodcastID     string     `json:"podcast_id"`
+	Title         string     `json:"title"`
+	Description   *string    `json:"description,omitempty"`
+	AudioURL      string     `json:"audio_url"`
+	ThumbnailURL  *string    `json:"thumbnail_url,omitempty"`
+	DurationSecs  *int       `json:"duration_secs,omitempty"`
+	EpisodeNumber *int       `json:"episode_number,omitempty"`
+	SeasonNumber  *int       `json:"season_number,omitempty"`
+	IsPremium     bool       `json:"is_premium"`
+	PublishedAt   *time.Time `json:"published_at,omitempty"`
+	CreatedAt     time.Time  `json:"created_at"`
+}
+
+type CreatePodcastRequest struct {
+	Title       string  `json:"title" binding:"required,min=2"`
+	Description *string `json:"description"`
+	ArtworkURL  *string `json:"artwork_url"`
+	Author      *string `json:"author"`
+	Category    *string `json:"category"`
+	IsPremium   bool    `json:"is_premium"`
+}
+
+type CreateEpisodeRequest struct {
+	PodcastID     string  `json:"podcast_id" binding:"required"`
+	Title         string  `json:"title" binding:"required,min=2"`
+	Description   *string `json:"description"`
+	AudioURL      string  `json:"audio_url" binding:"required"`
+	ThumbnailURL  *string `json:"thumbnail_url"`
+	DurationSecs  *int    `json:"duration_secs"`
+	EpisodeNumber *int    `json:"episode_number"`
+	SeasonNumber  *int    `json:"season_number"`
+	IsPremium     bool    `json:"is_premium"`
+}

--- a/backend/internal/podcasts/repository.go
+++ b/backend/internal/podcasts/repository.go
@@ -1,0 +1,142 @@
+package podcasts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Repository struct {
+	db *pgxpool.Pool
+}
+
+func NewRepository(db *pgxpool.Pool) *Repository {
+	return &Repository{db: db}
+}
+
+func (r *Repository) GetAllPodcasts(ctx context.Context) ([]*Podcast, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, title, description, artwork_url, author, category,
+		       is_premium, is_active, created_at
+		FROM podcasts WHERE is_active = true
+		ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("get podcasts: %w", err)
+	}
+	defer rows.Close()
+
+	var podcasts []*Podcast
+	for rows.Next() {
+		p := &Podcast{}
+		if err := rows.Scan(&p.ID, &p.Title, &p.Description, &p.ArtworkURL,
+			&p.Author, &p.Category, &p.IsPremium, &p.IsActive, &p.CreatedAt); err != nil {
+			return nil, err
+		}
+		podcasts = append(podcasts, p)
+	}
+	if podcasts == nil {
+		podcasts = []*Podcast{}
+	}
+	return podcasts, nil
+}
+
+func (r *Repository) GetPodcastByID(ctx context.Context, id string) (*Podcast, error) {
+	p := &Podcast{}
+	err := r.db.QueryRow(ctx, `
+		SELECT id, title, description, artwork_url, author, category,
+		       is_premium, is_active, created_at
+		FROM podcasts WHERE id = $1`, id).Scan(
+		&p.ID, &p.Title, &p.Description, &p.ArtworkURL,
+		&p.Author, &p.Category, &p.IsPremium, &p.IsActive, &p.CreatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return p, nil
+}
+
+func (r *Repository) GetEpisodes(ctx context.Context, podcastID string) ([]*Episode, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, podcast_id, title, description, audio_url, thumbnail_url,
+		       duration_secs, episode_number, season_number, is_premium,
+		       published_at, created_at
+		FROM episodes
+		WHERE podcast_id = $1
+		ORDER BY published_at DESC NULLS LAST, episode_number DESC NULLS LAST`,
+		podcastID)
+	if err != nil {
+		return nil, fmt.Errorf("get episodes: %w", err)
+	}
+	defer rows.Close()
+
+	var episodes []*Episode
+	for rows.Next() {
+		e := &Episode{}
+		if err := rows.Scan(&e.ID, &e.PodcastID, &e.Title, &e.Description,
+			&e.AudioURL, &e.ThumbnailURL, &e.DurationSecs, &e.EpisodeNumber,
+			&e.SeasonNumber, &e.IsPremium, &e.PublishedAt, &e.CreatedAt); err != nil {
+			return nil, err
+		}
+		episodes = append(episodes, e)
+	}
+	if episodes == nil {
+		episodes = []*Episode{}
+	}
+	return episodes, nil
+}
+
+func (r *Repository) GetEpisodeByID(ctx context.Context, id string) (*Episode, error) {
+	e := &Episode{}
+	err := r.db.QueryRow(ctx, `
+		SELECT id, podcast_id, title, description, audio_url, thumbnail_url,
+		       duration_secs, episode_number, season_number, is_premium,
+		       published_at, created_at
+		FROM episodes WHERE id = $1`, id).Scan(
+		&e.ID, &e.PodcastID, &e.Title, &e.Description,
+		&e.AudioURL, &e.ThumbnailURL, &e.DurationSecs, &e.EpisodeNumber,
+		&e.SeasonNumber, &e.IsPremium, &e.PublishedAt, &e.CreatedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return e, nil
+}
+
+func (r *Repository) CreatePodcast(ctx context.Context, req CreatePodcastRequest) (*Podcast, error) {
+	p := &Podcast{}
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO podcasts (title, description, artwork_url, author, category, is_premium)
+		VALUES ($1,$2,$3,$4,$5,$6)
+		RETURNING id, title, description, artwork_url, author, category,
+		          is_premium, is_active, created_at`,
+		req.Title, req.Description, req.ArtworkURL, req.Author,
+		req.Category, req.IsPremium).Scan(
+		&p.ID, &p.Title, &p.Description, &p.ArtworkURL,
+		&p.Author, &p.Category, &p.IsPremium, &p.IsActive, &p.CreatedAt)
+	return p, err
+}
+
+func (r *Repository) CreateEpisode(ctx context.Context, req CreateEpisodeRequest) (*Episode, error) {
+	e := &Episode{}
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO episodes (podcast_id, title, description, audio_url, thumbnail_url,
+		                      duration_secs, episode_number, season_number, is_premium)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+		RETURNING id, podcast_id, title, description, audio_url, thumbnail_url,
+		          duration_secs, episode_number, season_number, is_premium,
+		          published_at, created_at`,
+		req.PodcastID, req.Title, req.Description, req.AudioURL,
+		req.ThumbnailURL, req.DurationSecs, req.EpisodeNumber,
+		req.SeasonNumber, req.IsPremium).Scan(
+		&e.ID, &e.PodcastID, &e.Title, &e.Description,
+		&e.AudioURL, &e.ThumbnailURL, &e.DurationSecs, &e.EpisodeNumber,
+		&e.SeasonNumber, &e.IsPremium, &e.PublishedAt, &e.CreatedAt)
+	return e, err
+}

--- a/backend/internal/podcasts/service.go
+++ b/backend/internal/podcasts/service.go
@@ -1,0 +1,61 @@
+package podcasts
+
+import (
+	"context"
+	"errors"
+)
+
+var (
+	ErrPodcastNotFound = errors.New("podcast not found")
+	ErrEpisodeNotFound = errors.New("episode not found")
+	ErrPremiumRequired = errors.New("premium subscription required")
+)
+
+type Service struct {
+	repo *Repository
+}
+
+func NewService(repo *Repository) *Service {
+	return &Service{repo: repo}
+}
+
+func (s *Service) GetAll(ctx context.Context) ([]*Podcast, error) {
+	return s.repo.GetAllPodcasts(ctx)
+}
+
+func (s *Service) GetByID(ctx context.Context, id string) (*Podcast, error) {
+	p, err := s.repo.GetPodcastByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, ErrPodcastNotFound
+	}
+	return p, nil
+}
+
+func (s *Service) GetEpisodes(ctx context.Context, podcastID string) ([]*Episode, error) {
+	return s.repo.GetEpisodes(ctx, podcastID)
+}
+
+func (s *Service) GetEpisodeStreamURL(ctx context.Context, id string, isPremium bool) (string, error) {
+	e, err := s.repo.GetEpisodeByID(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	if e == nil {
+		return "", ErrEpisodeNotFound
+	}
+	if e.IsPremium && !isPremium {
+		return "", ErrPremiumRequired
+	}
+	return e.AudioURL, nil
+}
+
+func (s *Service) CreatePodcast(ctx context.Context, req CreatePodcastRequest) (*Podcast, error) {
+	return s.repo.CreatePodcast(ctx, req)
+}
+
+func (s *Service) CreateEpisode(ctx context.Context, req CreateEpisodeRequest) (*Episode, error) {
+	return s.repo.CreateEpisode(ctx, req)
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -3,15 +3,16 @@ package server
 import (
 	"net/http"
 
-	"github.com/gin-gonic/gin"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/redis/go-redis/v9"
 	"github.com/TgkCapture/openair/internal/auth"
 	"github.com/TgkCapture/openair/internal/channels"
+	"github.com/TgkCapture/openair/internal/content"
+	"github.com/TgkCapture/openair/internal/podcasts"
 	"github.com/TgkCapture/openair/pkg/config"
 	"github.com/TgkCapture/openair/pkg/middleware"
 	"github.com/TgkCapture/openair/pkg/token"
-	"github.com/TgkCapture/openair/internal/content"
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/redis/go-redis/v9"
 )
 
 type Server struct {
@@ -94,6 +95,14 @@ func (s *Server) setupRoutes() {
 	v1.GET("/vod/:id", contentHandler.GetByID)
 	v1.GET("/vod/:id/stream", contentHandler.GetPublicStreamURL)
 
+	podcastRepo := podcasts.NewRepository(s.db)
+	podcastSvc := podcasts.NewService(podcastRepo)
+	podcastHandler := podcasts.NewHandler(podcastSvc)
+
+	v1.GET("/podcasts", podcastHandler.GetAll)
+	v1.GET("/podcasts/:id", podcastHandler.GetByID)
+	v1.GET("/podcasts/:id/episodes", podcastHandler.GetEpisodes)
+
 	// Protected routes
 	protected := v1.Group("")
 	protected.Use(middleware.Auth(s.tokenManager))
@@ -109,6 +118,8 @@ func (s *Server) setupRoutes() {
 		protected.POST("/watch-history", contentHandler.SaveWatchHistory)
 		protected.GET("/watch-history", contentHandler.GetWatchHistory)
 
+		protected.GET("/podcasts/:id/episodes/:episodeId/stream", podcastHandler.GetEpisodeStreamURL)
+
 		// Admin only
 		admin := protected.Group("/admin")
 		admin.Use(middleware.RequireRole("admin"))
@@ -121,6 +132,9 @@ func (s *Server) setupRoutes() {
 			admin.POST("/vod", contentHandler.Create)
 			admin.PUT("/vod/:id", contentHandler.Update)
 			admin.PATCH("/vod/:id/access", contentHandler.ToggleAccess)
+
+			admin.POST("/podcasts", podcastHandler.CreatePodcast)
+			admin.POST("/podcasts/episodes", podcastHandler.CreateEpisode)
 		}
 	}
 }


### PR DESCRIPTION
Add CRUD operations for podcasts and episodes, including the ability to retrieve signed audio URLs. The implementation includes a handler, service, and repository for managing podcasts and episodes, along with the necessary routes for accessing and creating them. Premium episodes enforce subscription checks.

Fixes #21